### PR TITLE
Manage duplicate tweets differently; fixes blame after tweet

### DIFF
--- a/helga_poems/plugin.py
+++ b/helga_poems/plugin.py
@@ -2,6 +2,7 @@ import random
 import re
 
 from collections import defaultdict
+from datetime import datetime
 
 from twisted.internet import reactor
 
@@ -233,6 +234,16 @@ def tweet(client, channel, requested_by):
         client.msg(channel, msg)
         return
 
+    # Avoid duplicate tweets
+    tweet_document = db.haiku.find_one({'poem': last})
+    if tweet_document:
+        client.msg(channel, u'Message already tweeted on: {}'.format(tweet_document['date']))
+        return
+    db.haiku.insert({
+        'poem': last,
+        'date': datetime.now().strftime("%b %d %Y %H:%M:%S"),
+    })
+
     resp = send_tweet('\n'.join(last))
 
     if not resp:
@@ -240,8 +251,6 @@ def tweet(client, channel, requested_by):
         client.msg(channel, msg)
         return
 
-    # This will keep it from over tweeting
-    del last_poem[channel]
     client.msg(channel, resp)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tweepy==2.1
+tweepy


### PR DESCRIPTION
Save previous tweets in database so as to not duplicate content. Save date for helpful indicator to user if coincidentally a tweet occurs again.

This should fix the "!haiku blame" empty issue after a tweet, since last_poem was deleted.

Note: tweepy unpegging is in another PR, but I figured it is a gimme. Ping me if you want me to remove it :)

@shaunduncan 
